### PR TITLE
modified so that it works on a Raspbian

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@
     cd edu-image
     ./resize.sh
     ```
-1. A backup of the image will be created in ~/backups that can be used to create new cards if needed.
+1. A backup of the image will be created in ~/backups that can be used to create new cards if needed. If you're running this script on a Pi or a Desktop running Raspbian, then you'll need to install pv first: 
+	``` bash
+	sudo apt-get install pv
+	```

--- a/resize.sh
+++ b/resize.sh
@@ -32,7 +32,14 @@ echo "The following filesystems have been found:"
 lsblk
 read -e -p "Which blockdevice: " -i "mmcblk0" myblkdev
 read -e -p "Which partition do you want to shrink: " -i "2" targetpartnr
-targetpart="${myblkdev}p${targetpartnr}"
+if [ -e /etc/os-release ]
+then
+	echo 'os-release found'
+	if grep -q Raspbian /etc/os-release; then
+		echo 'Looks like this is Raspbian'
+		targetpart="${myblkdev}${targetpartnr}"
+	else
+		targetpart="${myblkdev}p${targetpartnr}"
 
 # Unmount directories, otherwise online shrinking from resize2fs would be
 # required but this throws an error.

--- a/resize.sh
+++ b/resize.sh
@@ -40,7 +40,8 @@ then
 		targetpart="${myblkdev}${targetpartnr}"
 	else
 		targetpart="${myblkdev}p${targetpartnr}"
-
+	fi
+fi
 # Unmount directories, otherwise online shrinking from resize2fs would be
 # required but this throws an error.
 if grep -s "${myblkdev}" /proc/mounts


### PR DESCRIPTION
If you use a Pi for this (or another Desktop running Raspbian), accessing the SD card via a usb reader,  partitions will be mounted as /dev/sda1 not /dev/sdap1. This mod to resize.sh checks to see if the script is being run on Raspbian and mounts the partition without the 'p' if it is.  Tested on latest Stretch Raspbian. 